### PR TITLE
ci: exclude cmd/ directory from coverage in GitHub Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,8 +24,8 @@ jobs:
     - name: Build
       run: go build -v ./...
 
-    - name: Run tests with coverage
-      run: go test -v ./... -coverprofile=coverage.out
+    - name: Run tests with coverage (excluding cmd/)
+      run: go test $(go list ./... | grep -v '/cmd/') -coverprofile=coverage.out
 
     - name: Show coverage report
       run: go tool cover -func=coverage.out


### PR DESCRIPTION
ci: exclude cmd/main.go from coverage in GitHub Actions

- Updated workflow to skip cmd/ directory when calculating coverage.
- Ensures main.go is not counted towards test coverage metrics.
- Prevents coverage drops due to untestable application entry points.
